### PR TITLE
Fixed bug in PlayerLocaleUpdateEvent

### DIFF
--- a/src/main/java/de/pierreschwang/spigotlib/event/PlayerLocaleUpdateEvent.java
+++ b/src/main/java/de/pierreschwang/spigotlib/event/PlayerLocaleUpdateEvent.java
@@ -13,19 +13,31 @@ public class PlayerLocaleUpdateEvent extends PlayerEvent {
 
     private static final HandlerList handlerList = new HandlerList();
     private final String oldLocale;
+    private final String newLocale;
 
-    public PlayerLocaleUpdateEvent(Player who, String oldLocale) {
+    public PlayerLocaleUpdateEvent(Player who, String oldLocale, String newLocale) {
         super(who);
         this.oldLocale = oldLocale;
+        this.newLocale = newLocale;
     }
 
     /**
-     * Get the old language of the client. The new language can be accessed using {@link User#getLocale()}.
+     * Get the old language of the client.
      *
      * @return The old locale.
      */
     public String getOldLocale() {
         return oldLocale;
+    }
+
+
+    /**
+     * Get the new language of the client.
+     *
+     * @return The new locale.
+     */
+    public String getNewLocale() {
+        return newLocale;
     }
 
     @Override

--- a/src/main/java/de/pierreschwang/spigotlib/internal/SettingsPacketInterceptor.java
+++ b/src/main/java/de/pierreschwang/spigotlib/internal/SettingsPacketInterceptor.java
@@ -62,7 +62,7 @@ public class SettingsPacketInterceptor {
                             return;
                         }
                         if (!locale.equals(user.getLocale()))
-                            Bukkit.getPluginManager().callEvent(new PlayerLocaleUpdateEvent(player, user.getLocale()));
+                            Bukkit.getPluginManager().callEvent(new PlayerLocaleUpdateEvent(player, user.getLocale(), locale));
                         user.setLocale(locale);
                         super.channelRead(channelHandlerContext, packet);
                     } catch (Exception e) {

--- a/src/main/java/de/pierreschwang/spigotlib/internal/interceptors/PacketPlayInSettingsInterceptor.java
+++ b/src/main/java/de/pierreschwang/spigotlib/internal/interceptors/PacketPlayInSettingsInterceptor.java
@@ -41,7 +41,7 @@ public class PacketPlayInSettingsInterceptor implements PacketInterceptor {
                     return;
                 }
                 if (!locale.equals(user.getLocale()))
-                    Bukkit.getPluginManager().callEvent(new PlayerLocaleUpdateEvent(player, user.getLocale()));
+                    Bukkit.getPluginManager().callEvent(new PlayerLocaleUpdateEvent(player, user.getLocale(), locale));
                 user.setLocale(locale);
             } catch (Exception e) {
                 e.printStackTrace();


### PR DESCRIPTION
There was no way of accessing the new locale, because the locale update (User Object) takes place after event handling.